### PR TITLE
Add missing replacement chars and remove conflicting. STDSDK-13 #resolve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <name>Santander SDK</name>
 
     <properties>
-        <version.org.fenixedu.bennu>6.3.1</version.org.fenixedu.bennu>
+        <version.org.fenixedu.bennu>6.5.0</version.org.fenixedu.bennu>
         <version.org.apache.cxf>3.1.10</version.org.apache.cxf>
         <version.org.imgscalr.imgscalr-lib>4.2</version.org.imgscalr.imgscalr-lib>
     </properties>

--- a/src/main/java/org/fenixedu/santandersdk/service/SantanderLineGenerator.java
+++ b/src/main/java/org/fenixedu/santandersdk/service/SantanderLineGenerator.java
@@ -2,6 +2,7 @@ package org.fenixedu.santandersdk.service;
 
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -27,7 +28,7 @@ public class SantanderLineGenerator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SantanderLineGenerator.class);
     private final Map<String, String> charReplacementMap = new HashMap<>();
-    private final CharsetEncoder latin1CharsetEncoder = Charset.forName("ISO-8859-1").newEncoder();
+    private final CharsetEncoder latin1CharsetEncoder = StandardCharsets.ISO_8859_1.newEncoder();
 
     private SantanderEntryValidator santanderEntryValidator;
 
@@ -374,7 +375,8 @@ public class SantanderLineGenerator {
         charReplacementMap.put("Ü", "U");
         charReplacementMap.put("ş", "s");
         charReplacementMap.put("Ş", "S");
-        charReplacementMap.put("'", " ");
+        charReplacementMap.put("Ä", "A");
+        charReplacementMap.put("ä", "a");
     }
 
 }


### PR DESCRIPTION
- Removed apostrophe from the charReplacementMap. This is not needed and **conflicts** with the [changes made on fenixedu-id-cards](https://github.com/ist-dsi/fenixedu-id-cards/pull/84);
- Added new char to charReplacementMap "Ä" (lower case "ä");
- Bumps bennu.